### PR TITLE
fix: set empty BABASHKA_CLASSPATH

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -23,7 +23,8 @@ stdenv.mkDerivation rec {
 
     # Wrap to ensure babashka is on PATH
     wrapProgram $out/bin/brepl \
-      --prefix PATH : ${lib.makeBinPath [ babashka ]}
+      --prefix PATH : ${lib.makeBinPath [ babashka ]} \
+      --set BABASHKA_CLASSPATH ""
 
     runHook postInstall
   '';


### PR DESCRIPTION
Hi,

This fix is to ensure the uberscript brepl installed not be affected by the bb.edn file in local folder when running the brepl inside that folder.

For example, in folder ~/user/project, if that folder happens to contain a bb.edn with deps (not relevant to brepl), running brepl would still download that deps from bb.edn, which is not correct.

I only fixed the nix version in this pr. You may need to advice/fix the wrap approach either with the BABASHKA_CLASSPATH empty approach or `bb --config nil ubserscript` for other platforms.
 
 https://github.com/NixOS/nixpkgs/pull/454426